### PR TITLE
Change bal build command to bal pack  in the release yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: ballerina-platform/ballerina-action/@slbeta6
         with:
           args:
-            build
+            pack
       - name: Ballerina Push
         uses: ballerina-platform/ballerina-action/@slbeta6
         with:


### PR DESCRIPTION
## Purpose
Got the following error when releasing the connector

`cannot find bala file for the package: postgresql.driver. Run 'bal pack' to compile and generate the bala.`

Hence, This PR has been changed that build command.