### PR TITLE
Bump pgjdbc to 42.7.7 for Debezium 3.5.1 compatibility

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "postgresql.driver"
-version = "1.6.3"
+version = "1.6.4"
 authors = ["Ballerina"]
 keywords = ["Vendor/PostgreSQL", "Area/Database", "Type/Driver"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql.driver"
@@ -13,10 +13,10 @@ distribution = "2201.11.0"
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
-path = "./lib/postgresql-42.6.1.jar"
+path = "./lib/postgresql-42.7.7.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "postgresql.driver-native"
-version = "1.6.3"
-path = "../native/build/libs/postgresql.driver-native-1.6.3.jar"
+version = "1.6.4"
+path = "../native/build/libs/postgresql.driver-native-1.6.4.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "postgresql.driver"
-version = "1.6.4"
+version = "1.7.0"
 authors = ["Ballerina"]
 keywords = ["Vendor/PostgreSQL", "Area/Database", "Type/Driver"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql.driver"
@@ -18,5 +18,5 @@ path = "./lib/postgresql-42.7.7.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "postgresql.driver-native"
-version = "1.6.4"
-path = "../native/build/libs/postgresql.driver-native-1.6.4.jar"
+version = "1.7.0"
+path = "../native/build/libs/postgresql.driver-native-1.7.0-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["Vendor/PostgreSQL", "Area/Database", "Type/Driver"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.11.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -13,6 +13,9 @@ distribution = "2201.13.0"
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
+groupId = "org.postgresql"
+artifactId = "postgresql"
+version = "42.7.7"
 path = "./lib/postgresql-42.7.7.jar"
 
 [[platform.java21.dependency]]

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "org.postgresql"
 artifactId = "postgresql"
-version = "42.7.7"
-path = "./lib/postgresql-42.7.7.jar"
+version = "42.7.13"
+path = "./lib/postgresql-42.7.13.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["Vendor/PostgreSQL", "Area/Database", "Type/Driver"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.11.0"
+distribution = "2201.13.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.11.0"
 
 [[package]]
 org = "ballerinax"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.11.0"
 [[package]]
 org = "ballerinax"
 name = "postgresql.driver"
-version = "1.6.4"
+version = "1.7.0"
 modules = [
 	{org = "ballerinax", packageName = "postgresql.driver", moduleName = "postgresql.driver"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerinax"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.11.0"
 [[package]]
 org = "ballerinax"
 name = "postgresql.driver"
-version = "1.6.3"
+version = "1.6.4"
 modules = [
 	{org = "ballerinax", packageName = "postgresql.driver", moduleName = "postgresql.driver"}
 ]

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -13,6 +13,9 @@ distribution = "2201.13.0"
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
+groupId = "org.postgresql"
+artifactId = "postgresql"
+version = "@postgresql.driver.version@"
 path = "./lib/postgresql-@postgresql.driver.version@.jar"
 
 [[platform.java21.dependency]]

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["Vendor/PostgreSQL", "Area/Database", "Type/Driver"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.11.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["Vendor/PostgreSQL", "Area/Database", "Type/Driver"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql.driver"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.11.0"
+distribution = "2201.13.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ underCouchDownloadVersion=5.4.0
 researchgateReleaseVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
-ballerinaLangVersion=2201.11.0
+ballerinaLangVersion=2201.13.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=1.7.0-SNAPSHOT
 
 githubSpotbugsVersion=6.0.18
 githubJohnrengelmanShadowVersion=8.1.1
-postgreSQLDriverVersion=42.7.7
+postgreSQLDriverVersion=42.7.13
 underCouchDownloadVersion=5.4.0
 researchgateReleaseVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group=io.ballerina.stdlib
-version=1.6.4-SNAPSHOT
+version=1.7.0-SNAPSHOT
 
 githubSpotbugsVersion=6.0.18
 githubJohnrengelmanShadowVersion=8.1.1
-postgreSQLDriverVersion=42.6.1
+postgreSQLDriverVersion=42.7.7
 underCouchDownloadVersion=5.4.0
 researchgateReleaseVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ underCouchDownloadVersion=5.4.0
 researchgateReleaseVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.11.0


### PR DESCRIPTION
## Summary
- Bumps the bundled pgjdbc driver from 42.6.1 to 42.7.7.
- Debezium 3.5.1's Postgres connector calls `ChainedLogicalStreamBuilder.withAutomaticFlush(boolean)`, which does not exist on pgjdbc 42.6.1, causing a `NoSuchMethodError` at runtime. 42.7.7 is Debezium's own required pgjdbc version.
- Also bumps package version 1.6.3 → 1.7.0 and the Ballerina distribution used for building.

## Test plan
- [x] Rebuilt the driver locally (`postgresql-42.7.7.jar` confirmed bundled in the produced bala).
- [x] Verified against `module-ballerinax-postgresql`'s CDC listener test suite (`testCdcListenerEvents`, full `cdc` group) with the rebuilt driver — all passing, where they previously failed with `NoSuchMethodError` under Debezium 3.5.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the bundled PostgreSQL JDBC driver from **42.6.1** to **42.7.13** to improve **Debezium 3.5.1** compatibility and address a runtime incompatibility due to a driver API mismatch.
- Bumped the package version from **1.6.3** to **1.7.0**, including the corresponding `postgresql.driver-native` version and rebuilt driver/native artifacts.
- Rebuilt the distribution using the Ballerina distribution version **2201.11.0**, aligning the build configuration and dependency metadata accordingly.
- Verified the **CDC listener** test suite passes with the updated driver artifacts (including the `postgresql-42.7.13.jar` update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->